### PR TITLE
transducers-intro: fix mapper's typing

### DIFF
--- a/org/2020-06-13-transducers-intro.org
+++ b/org/2020-06-13-transducers-intro.org
@@ -261,9 +261,9 @@ Hope you brought your swimming trunks, we're going on a deep dive.
    #+begin_src haskell
      f :: a -> b
      mapper :: (a -> b) -> (rf -> (accum -> a -> accum))
-     rf :: accum -> a -> accum
+     rf :: accum -> b -> accum
      --
-     mapper :: (a -> b) -> ((accum -> a -> accum) -> (accum' -> a' -> accum'))
+     mapper :: (a -> b) -> ((accum -> b -> accum) -> (accum -> a -> accum))
      mapper :: (a -> b) -> (rf -> rf')
    #+end_src
 


### PR DESCRIPTION
Hello! You probably have some mistake in `-mapper` type signature in "Why do they compose?" section.

Let's check it more precisely. Start from definition of `-mapper`
```clojure
(defn -mapper [f]
  (fn [rf]
    (fn [acc x] (rf acc (f x)))))
```
Its type should be something like this (I added `t` to type names to distinguish them from parameter names):
```haskell
mapper :: tf -> trf -> tacc -> tx -> ty
-- where
tf = a -> b

-- to type `(f x)` it shold be right:
x :: a = tx
f x :: b

-- then to type `(rf acc (f x))` it should be right:
trf = tacc -> b -> tacc
rf acc (f x) :: trf tacc b = (tacc -> b -> tacc) tacc b = tacc = ty

-- and finally we get:
mapper :: (a -> b) -> (tacc -> b -> tacc) -> tacc -> a -> tacc

```

And self-check:
```sh
$ ghci
GHCi, version 8.6.5: http://www.haskell.org/ghc/  :? for help
Prelude> mapper f rf acc x = rf acc (f x)
Prelude> :t mapper
mapper :: (t1 -> t2) -> (t3 -> t2 -> t4) -> t3 -> t1 -> t4
```
